### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
 ![Screenshot](http://pic.yupoo.com/diwup_v/BYUiqm9y/fcPez.jpg)
-#Tiny Wings Remake on Android
+# Tiny Wings Remake on Android
 * Powered by [Cocos2d-X](http://www.cocos2d-x.org/) & [Box2D](http://box2d.org/)
 * Inspired by and ported from [haqu / tiny-wings](https://github.com/haqu/tiny-wings)
 * Runs on both Android and iOS
 * Youtube demo: <http://youtu.be/4ISI_70pYGs>
 * Youku demo: <http://v.youku.com/v_show/id_XNDAwMDgyNzgw.html>
 
-#Play with It
+# Play with It
 1. There's an .apk alongside the source code.
 2. Or, you can build and run the souce code yourself. The Cocos2d-x and Box2D libs are included already. But you still need to ***modify the build_native.sh script*** so that the Android NDK recognizes the relative path for those libs on your Mac.
 
-#Compatibility
+# Compatibility
 Tested OK on my Nexus S (Android 4.0) and my iPhone 4s (iOS 5.0).
 
-#License
+# License
 The code is released under the [MIT License](http://opensource.org/licenses/mit-license.php).
 
-#Contact
+# Contact
 <diwufet@gmail.com>


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
